### PR TITLE
Previously, the flow would always redirect to authorize page, even if…

### DIFF
--- a/src/Flutter.js
+++ b/src/Flutter.js
@@ -128,8 +128,9 @@ Flutter.prototype.connect = function(req, res, next) {
 
     self.opts.connectCallback(req, res, next);
 
-    // redirect the user to the authorise page
-    res.redirect("https://twitter.com/oauth/authorize?oauth_token=" + token);
+    // sign in the user if the user has previously connected, else ask for authorization. 
+    // see https://dev.twitter.com/oauth/reference/get/oauth/authenticate
+    res.redirect("https://twitter.com/oauth/authenticate?oauth_token=" + token);
 
   });
 };


### PR DESCRIPTION
… the

user had already authorized the app once. This leads to bad UX. Also, I think
the auth tokens will be regenerated with new authorization, which would require
us to save the tokens again in our data store.

By just using the authenticate api, this issue is resolved. See https://dev.twitter.com/oauth/reference/get/oauth/authenticate
