### PR TITLE
Require and use express-session in example code - fixes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ var flutter = new Flutter({
 });
 
 var app = express();
+var session = require('express-session');
+app.use(session({secret: 'keyboard cat'}));
 
 app.get('/twitter/connect', flutter.connect);
 


### PR DESCRIPTION
require and use express-session so req.session can be used to store
tokens in request handlers
